### PR TITLE
Fix zero rtt with invalid id/seq

### DIFF
--- a/fastping.go
+++ b/fastping.go
@@ -651,7 +651,11 @@ func (p *Pinger) procRecv(recv *packet, queue map[string]*net.IPAddr) {
 		p.mu.Lock()
 		if pkt.ID == p.id && pkt.Seq == p.seq {
 			rtt = time.Since(bytesToTime(pkt.Data[:TimeSliceLength]))
+		} else {
+			p.mu.Unlock()
+			return
 		}
+
 		p.mu.Unlock()
 	default:
 		return


### PR DESCRIPTION
In case of more instances of application which uses go-fastping is pinging same ip it's possible to get responces with zero rtt. This small patch fixes it
