### PR TITLE
error parameter

### DIFF
--- a/fastping_test.go
+++ b/fastping_test.go
@@ -22,7 +22,7 @@ func TestSource(t *testing.T) {
 		origSource, err := p.Source(tt.firstAddr)
 		if tt.invalid {
 			if err == nil {
-				t.Errorf("[%d] Source should return an error but nothing: %v", i)
+				t.Errorf("[%d] Source should return an error but nothing", i)
 			}
 			continue
 		}


### PR DESCRIPTION
If you call `go vet` 

```bash
go-fastping/fastping_test.go:25: T.Errorf format %v reads arg #2, but call has 1 arg
make: *** [validate] Error 2
ERROR: Job failed: exit status 1
```