### PR TITLE
Fix tests on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ please see "cmd/ping/ping.go".
 This package implements ICMP ping using both raw socket and UDP. If your program
 uses this package in raw socket mode, it needs to be run as a root user.
 
+If you are using the UDP socket on Linux, you may also need to allow UDP pings (even root is not allowed by default on debian for example):
+```
+sudo sysctl -w net.ipv4.ping_group_range="0 2147483647"
+```
+
 ## License
 go-fastping is under MIT License. See the [LICENSE][license] file for details.
 

--- a/fastping_test.go
+++ b/fastping_test.go
@@ -165,7 +165,7 @@ func TestRun(t *testing.T) {
 			t.Fatalf("AddIP failed: %v", err)
 		}
 
-		if err := p.AddIP("127.0.0.100"); err != nil {
+		if err := p.AddIP("198.51.100.100"); err != nil {
 			t.Fatalf("AddIP failed: %v", err)
 		}
 
@@ -179,7 +179,7 @@ func TestRun(t *testing.T) {
 			called = true
 			if ip.String() == "127.0.0.1" {
 				found1 = true
-			} else if ip.String() == "127.0.0.100" {
+			} else if ip.String() == "198.51.100.100" {
 				found100 = true
 			} else if ip.String() == "::1" {
 				foundv6 = true
@@ -204,7 +204,7 @@ func TestRun(t *testing.T) {
 			t.Fatalf("Pinger `127.0.0.1` didn't respond")
 		}
 		if found100 {
-			t.Fatalf("Pinger `127.0.0.100` responded")
+			t.Fatalf("Pinger `198.51.100.100` responded")
 		}
 		if !foundv6 {
 			t.Fatalf("Pinger `::1` didn't responded")


### PR DESCRIPTION
In fastping_test.go the address 127.0.0.100 is used to test non-response, but it is a valid loopback IP, and answer to pings (at least on Linux).
I replaced it with 198.51.100.100 (to keep the "100" spirit) which is an IP address from TEST-NET-2 (RFC 5737) which should never exist in production network, so there is little to no chance for it to answer when running tests.

There is also a sysctl config to change for UDP ping to work. (At least on debian-based ones, I tested on Ubuntu and Debian, haven't tested on others) and I added it to README